### PR TITLE
Return of boolean expressions should not be wrapped into an "if-then-else" statement

### DIFF
--- a/app/src/main/java/in/co/praveenkumar/mdroid/fragment/CalenderFragment.java
+++ b/app/src/main/java/in/co/praveenkumar/mdroid/fragment/CalenderFragment.java
@@ -231,10 +231,7 @@ public class CalenderFragment extends Fragment implements OnRefreshListener {
 
 		@Override
 		public boolean isItemViewTypePinned(int viewType) {
-			if (viewType == TYPE_DATE)
-				return true;
-			else
-				return false;
+			return viewType == TYPE_DATE;
 		}
 
 		@Override

--- a/app/src/main/java/in/co/praveenkumar/mdroid/fragment/ContactFragment.java
+++ b/app/src/main/java/in/co/praveenkumar/mdroid/fragment/ContactFragment.java
@@ -183,10 +183,7 @@ public class ContactFragment extends Fragment implements OnRefreshListener {
 		protected Boolean doInBackground(String... params) {
 			ContactSyncTask cst = new ContactSyncTask(session.getmUrl(),
 					session.getToken(), session.getCurrentSiteId());
-			if (cst.syncAllContacts())
-				return true;
-			else
-				return false;
+			return cst.syncAllContacts();
 		}
 
 		@Override

--- a/app/src/main/java/in/co/praveenkumar/mdroid/fragment/ContentFragment.java
+++ b/app/src/main/java/in/co/praveenkumar/mdroid/fragment/ContentFragment.java
@@ -120,10 +120,7 @@ public class ContentFragment extends Fragment implements OnRefreshListener {
 			// Save all sections into a listObject array for easy access inside
 			mapSectionsToListObjects(sections);
 
-			if (syncStatus)
-				return true;
-			else
-				return false;
+			return syncStatus;
 		}
 
 		@Override
@@ -291,10 +288,7 @@ public class ContentFragment extends Fragment implements OnRefreshListener {
 
 		@Override
 		public boolean isItemViewTypePinned(int viewType) {
-			if (viewType == TYPE_HEADER)
-				return true;
-			else
-				return false;
+			return viewType == TYPE_HEADER;
 		}
 
 		@Override

--- a/app/src/main/java/in/co/praveenkumar/mdroid/fragment/CourseFragment.java
+++ b/app/src/main/java/in/co/praveenkumar/mdroid/fragment/CourseFragment.java
@@ -274,10 +274,7 @@ public class CourseFragment extends Fragment implements OnRefreshListener {
 		protected Boolean doInBackground(String... params) {
 			CourseSyncTask cs = new CourseSyncTask(session.getmUrl(),
 					session.getToken(), session.getCurrentSiteId());
-			if (cs.syncUserCourses())
-				return true;
-			else
-				return false;
+			return cs.syncUserCourses();
 		}
 
 		@Override

--- a/app/src/main/java/in/co/praveenkumar/mdroid/fragment/MessageListingFragment.java
+++ b/app/src/main/java/in/co/praveenkumar/mdroid/fragment/MessageListingFragment.java
@@ -116,10 +116,7 @@ public class MessageListingFragment extends Fragment implements
             // Sync from server and update
             MessageSyncTask mst = new MessageSyncTask(session.getmUrl(),
                     session.getToken(), session.getCurrentSiteId());
-            if (mst.syncMessages(session.getSiteInfo().getUserid()))
-                return true;
-            else
-                return false;
+            return mst.syncMessages(session.getSiteInfo().getUserid());
         }
 
         @Override

--- a/app/src/main/java/in/co/praveenkumar/mdroid/fragment/MessagingFragment.java
+++ b/app/src/main/java/in/co/praveenkumar/mdroid/fragment/MessagingFragment.java
@@ -144,10 +144,7 @@ public class MessagingFragment extends Fragment implements OnRefreshListener {
 			// Sync from server and update
 			MessageSyncTask mst = new MessageSyncTask(session.getmUrl(),
 					session.getToken(), session.getCurrentSiteId());
-			if (mst.syncMessages(session.getSiteInfo().getUserid()))
-				return true;
-			else
-				return false;
+			return mst.syncMessages(session.getSiteInfo().getUserid());
 		}
 
 		@Override

--- a/app/src/main/java/in/co/praveenkumar/mdroid/fragment/ParticipantFragment.java
+++ b/app/src/main/java/in/co/praveenkumar/mdroid/fragment/ParticipantFragment.java
@@ -175,10 +175,7 @@ public class ParticipantFragment extends Fragment implements OnRefreshListener {
 		protected Boolean doInBackground(String... params) {
 			UserSyncTask ust = new UserSyncTask(session.getmUrl(),
 					session.getToken(), session.getCurrentSiteId());
-			if (ust.syncUsers(courseid))
-				return true;
-			else
-				return false;
+			return ust.syncUsers(courseid);
 		}
 
 		@Override

--- a/app/src/main/java/in/co/praveenkumar/mdroid/fragment/RightNavigationFragment.java
+++ b/app/src/main/java/in/co/praveenkumar/mdroid/fragment/RightNavigationFragment.java
@@ -183,10 +183,7 @@ public class RightNavigationFragment extends Fragment {
 		protected Boolean doInBackground(String... params) {
 			ContactSyncTask cst = new ContactSyncTask(session.getmUrl(),
 					session.getToken(), session.getCurrentSiteId());
-			if (cst.syncAllContacts())
-				return true;
-			else
-				return false;
+			return cst.syncAllContacts();
 		}
 
 		@Override


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1126 - “Return of boolean expressions should not be wrapped into an "if-then-else" statement”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1126
Please let me know if you have any questions.
Ayman Abdelghany.