### PR TITLE
 Primitives should not be boxed just for "String" conversion

### DIFF
--- a/app/src/main/java/in/co/praveenkumar/mdroid/activity/CourseContentActivity.java
+++ b/app/src/main/java/in/co/praveenkumar/mdroid/activity/CourseContentActivity.java
@@ -42,8 +42,8 @@ public class CourseContentActivity extends BaseNavigationActivity {
 		// Get course details
 		SessionSetting session = new SessionSetting(this);
 		List<MoodleCourse> dbCourses = MoodleCourse.find(MoodleCourse.class,
-				"siteid = ? and courseid = ?", session.getCurrentSiteId() + "",
-				courseid + "");
+				"siteid = ? and courseid = ?", String.valueOf(session.getCurrentSiteId()),
+				String.valueOf(courseid));
 		if (dbCourses == null || dbCourses.size() == 0) {
 			Toast.makeText(this, "Course not found in database!",
 					Toast.LENGTH_LONG).show();

--- a/app/src/main/java/in/co/praveenkumar/mdroid/activity/CourseContentActivity.java
+++ b/app/src/main/java/in/co/praveenkumar/mdroid/activity/CourseContentActivity.java
@@ -44,7 +44,7 @@ public class CourseContentActivity extends BaseNavigationActivity {
 		List<MoodleCourse> dbCourses = MoodleCourse.find(MoodleCourse.class,
 				"siteid = ? and courseid = ?", String.valueOf(session.getCurrentSiteId()),
 				String.valueOf(courseid));
-		if (dbCourses == null || dbCourses.size() == 0) {
+		if (dbCourses == null || dbCourses.isEmpty()) {
 			Toast.makeText(this, "Course not found in database!",
 					Toast.LENGTH_LONG).show();
 			return;

--- a/app/src/main/java/in/co/praveenkumar/mdroid/activity/DiscussionActivity.java
+++ b/app/src/main/java/in/co/praveenkumar/mdroid/activity/DiscussionActivity.java
@@ -29,8 +29,8 @@ public class DiscussionActivity extends BaseNavigationActivity implements
 		// Set title
 		SessionSetting session = new SessionSetting(this);
 		List<MoodleForum> mForums = MoodleForum.find(MoodleForum.class,
-				"forumid = ? and siteid = ?", forumid + "",
-				session.getCurrentSiteId() + "");
+				"forumid = ? and siteid = ?", String.valueOf(forumid),
+				String.valueOf(session.getCurrentSiteId()));
 		if (mForums.size() > 0)
 			getSupportActionBar().setTitle(mForums.get(0).getName());
 		getSupportActionBar().setIcon(R.drawable.icon_forum);

--- a/app/src/main/java/in/co/praveenkumar/mdroid/activity/DiscussionActivity.java
+++ b/app/src/main/java/in/co/praveenkumar/mdroid/activity/DiscussionActivity.java
@@ -31,7 +31,7 @@ public class DiscussionActivity extends BaseNavigationActivity implements
 		List<MoodleForum> mForums = MoodleForum.find(MoodleForum.class,
 				"forumid = ? and siteid = ?", String.valueOf(forumid),
 				String.valueOf(session.getCurrentSiteId()));
-		if (mForums.size() > 0)
+		if (!mForums.isEmpty())
 			getSupportActionBar().setTitle(mForums.get(0).getName());
 		getSupportActionBar().setIcon(R.drawable.icon_forum);
 	}

--- a/app/src/main/java/in/co/praveenkumar/mdroid/activity/DonationActivity.java
+++ b/app/src/main/java/in/co/praveenkumar/mdroid/activity/DonationActivity.java
@@ -32,7 +32,7 @@ import com.google.gson.reflect.TypeToken;
 
 public class DonationActivity extends BaseNavigationActivity {
 	private final String DEBUG_TAG = "DonationActivity";
-	List<MDroidFeature> features = new ArrayList<MDroidFeature>();
+	List<MDroidFeature> features = new ArrayList<>();
 	Context context;
 	FeatureListAdapter featureListAdapter;
 

--- a/app/src/main/java/in/co/praveenkumar/mdroid/activity/PostActivity.java
+++ b/app/src/main/java/in/co/praveenkumar/mdroid/activity/PostActivity.java
@@ -29,7 +29,7 @@ public class PostActivity extends BaseNavigationActivity implements
 		SessionSetting session = new SessionSetting(this);
 		List<MoodleDiscussion> mDiscussions = MoodleDiscussion.find(
 				MoodleDiscussion.class, "discussionid = ? and siteid = ?",
-				discussionid + "", session.getCurrentSiteId() + "");
+				String.valueOf(discussionid), String.valueOf(session.getCurrentSiteId()));
 		if (mDiscussions.size() > 0)
 			getSupportActionBar().setTitle(mDiscussions.get(0).getName());
 		getSupportActionBar().setIcon(R.drawable.icon_forum);

--- a/app/src/main/java/in/co/praveenkumar/mdroid/activity/PostActivity.java
+++ b/app/src/main/java/in/co/praveenkumar/mdroid/activity/PostActivity.java
@@ -30,7 +30,7 @@ public class PostActivity extends BaseNavigationActivity implements
 		List<MoodleDiscussion> mDiscussions = MoodleDiscussion.find(
 				MoodleDiscussion.class, "discussionid = ? and siteid = ?",
 				String.valueOf(discussionid), String.valueOf(session.getCurrentSiteId()));
-		if (mDiscussions.size() > 0)
+		if (!mDiscussions.isEmpty())
 			getSupportActionBar().setTitle(mDiscussions.get(0).getName());
 		getSupportActionBar().setIcon(R.drawable.icon_forum);
 	}

--- a/app/src/main/java/in/co/praveenkumar/mdroid/dialog/LogoutDialog.java
+++ b/app/src/main/java/in/co/praveenkumar/mdroid/dialog/LogoutDialog.java
@@ -86,28 +86,26 @@ public class LogoutDialog extends Dialog implements
 
 	public void performLogout(long siteid) {
 		// Delete siteinfo
-		MoodleSiteInfo.deleteAll(MoodleSiteInfo.class, "id = ?", siteid + "");
+		MoodleSiteInfo.deleteAll(MoodleSiteInfo.class, "id = ?", String.valueOf(siteid));
 
 		// set a new site from db as current site. The below call will pick a
 		// new site from db as current site
 		SessionSetting session = new SessionSetting(context);
 
 		// Now delete all other info related to that site
-		MoodleContact.deleteAll(MoodleContact.class, "siteid = ?", siteid + "");
-		MoodleCourse.deleteAll(MoodleCourse.class, "siteid = ?", siteid + "");
-		MoodleDiscussion.deleteAll(MoodleDiscussion.class, "siteid = ?", siteid
-				+ "");
-		MoodleEvent.deleteAll(MoodleEvent.class, "siteid = ?", siteid + "");
-		MoodleForum.deleteAll(MoodleForum.class, "siteid = ?", siteid + "");
-		MoodleMessage.deleteAll(MoodleMessage.class, "siteid = ?", siteid + "");
-		MoodleModule.deleteAll(MoodleModule.class, "siteid = ?", siteid + "");
+		MoodleContact.deleteAll(MoodleContact.class, "siteid = ?", String.valueOf(siteid));
+		MoodleCourse.deleteAll(MoodleCourse.class, "siteid = ?", String.valueOf(siteid));
+		MoodleDiscussion.deleteAll(MoodleDiscussion.class, "siteid = ?", String.valueOf(siteid));
+		MoodleEvent.deleteAll(MoodleEvent.class, "siteid = ?", String.valueOf(siteid));
+		MoodleForum.deleteAll(MoodleForum.class, "siteid = ?", String.valueOf(siteid));
+		MoodleMessage.deleteAll(MoodleMessage.class, "siteid = ?", String.valueOf(siteid));
+		MoodleModule.deleteAll(MoodleModule.class, "siteid = ?", String.valueOf(siteid));
 		MoodleModuleContent.deleteAll(MoodleModuleContent.class, "siteid = ?",
-				siteid + "");
-		MoodlePost.deleteAll(MoodlePost.class, "siteid = ?", siteid + "");
-		MoodleSection.deleteAll(MoodleSection.class, "siteid = ?", siteid + "");
-		MoodleUser.deleteAll(MoodleUser.class, "siteid = ?", siteid + "");
-		MoodleUserCourse.deleteAll(MoodleUserCourse.class, "siteid = ?", siteid
-				+ "");
+				String.valueOf(siteid));
+		MoodlePost.deleteAll(MoodlePost.class, "siteid = ?", String.valueOf(siteid));
+		MoodleSection.deleteAll(MoodleSection.class, "siteid = ?", String.valueOf(siteid));
+		MoodleUser.deleteAll(MoodleUser.class, "siteid = ?", String.valueOf(siteid));
+		MoodleUserCourse.deleteAll(MoodleUserCourse.class, "siteid = ?", String.valueOf(siteid));
 
 		Intent i;
 		if (session.getCurrentSiteId() == SessionSetting.NO_SITE_ID)

--- a/app/src/main/java/in/co/praveenkumar/mdroid/dialog/MessageDialog.java
+++ b/app/src/main/java/in/co/praveenkumar/mdroid/dialog/MessageDialog.java
@@ -47,12 +47,12 @@ public class MessageDialog extends Dialog implements
 		// Set values
 		char letter = (contact.getFullname().length() > 0) ? contact
 				.getFullname().charAt(0) : '0';
-		userImage.setText(letter + "");
+		userImage.setText(String.valueOf(letter));
 		userName.setText(contact.getFullname());
 		userImage.setBackgroundColor(LetterColor.of(letter));
 		headerLine.setBackgroundColor(LetterColor.of(letter));
 		if (contact.getUnread() > 0)
-			unreadCount.setText(contact.getUnread() + "");
+			unreadCount.setText(String.valueOf(contact.getUnread()));
 		else
 			unreadCount.setVisibility(TextView.GONE);
 

--- a/app/src/main/java/in/co/praveenkumar/mdroid/dialog/UserinfoDialog.java
+++ b/app/src/main/java/in/co/praveenkumar/mdroid/dialog/UserinfoDialog.java
@@ -52,16 +52,16 @@ public class UserinfoDialog extends Dialog implements
 		this.session = new SessionSetting(context);
 		siteinfo = MoodleSiteInfo.findById(MoodleSiteInfo.class, siteid);
 		List<MoodleUser> mUsers = MoodleUser.find(MoodleUser.class,
-				"userid = ? and siteid = ?", userid + "", siteid + "");
+				"userid = ? and siteid = ?", String.valueOf(userid), String.valueOf(siteid));
 		if (mUsers != null && mUsers.size() > 0)
 			user = mUsers.get(0);
 		mCourses = MoodleUserCourse
 				.find(MoodleUserCourse.class, "userid = ? and siteid = ?",
-						user.getUserid() + "", siteid + "");
+						String.valueOf(user.getUserid()), String.valueOf(siteid));
 
 		// Check if this user is a contact
 		List<MoodleContact> mContacts = MoodleContact.find(MoodleContact.class,
-				"contactid = ? and siteid = ?", userid + "", siteid + "");
+				"contactid = ? and siteid = ?", String.valueOf(userid), String.valueOf(siteid));
 		isContact = (mContacts != null && mContacts.size() != 0);
 
 	}
@@ -116,7 +116,7 @@ public class UserinfoDialog extends Dialog implements
 		char firstChar = 0;
 		if (name.length() != 0)
 			firstChar = name.charAt(0);
-		userImage.setText(firstChar + "");
+		userImage.setText(String.valueOf(firstChar));
 		userImage.setBackgroundColor(LetterColor.of(firstChar));
 		userFullname.setText(user.getFullname());
 

--- a/app/src/main/java/in/co/praveenkumar/mdroid/dialog/UserinfoDialog.java
+++ b/app/src/main/java/in/co/praveenkumar/mdroid/dialog/UserinfoDialog.java
@@ -53,7 +53,7 @@ public class UserinfoDialog extends Dialog implements
 		siteinfo = MoodleSiteInfo.findById(MoodleSiteInfo.class, siteid);
 		List<MoodleUser> mUsers = MoodleUser.find(MoodleUser.class,
 				"userid = ? and siteid = ?", String.valueOf(userid), String.valueOf(siteid));
-		if (mUsers != null && mUsers.size() > 0)
+		if (mUsers != null && !mUsers.isEmpty())
 			user = mUsers.get(0);
 		mCourses = MoodleUserCourse
 				.find(MoodleUserCourse.class, "userid = ? and siteid = ?",
@@ -62,7 +62,7 @@ public class UserinfoDialog extends Dialog implements
 		// Check if this user is a contact
 		List<MoodleContact> mContacts = MoodleContact.find(MoodleContact.class,
 				"contactid = ? and siteid = ?", String.valueOf(userid), String.valueOf(siteid));
-		isContact = (mContacts != null && mContacts.size() != 0);
+		isContact = (mContacts != null && !mContacts.isEmpty());
 
 	}
 
@@ -225,8 +225,7 @@ public class UserinfoDialog extends Dialog implements
 				if (isContact)
 					MoodleContact.deleteAll(MoodleContact.class,
 							"siteid = ? and contactid = ?",
-							session.getCurrentSiteId() + "", user.getUserid()
-									+ "");
+							String.valueOf(session.getCurrentSiteId()), String.valueOf(user.getUserid()));
 				cst.syncAllContacts();
 			}
 			return status;

--- a/app/src/main/java/in/co/praveenkumar/mdroid/fragment/CalenderFragment.java
+++ b/app/src/main/java/in/co/praveenkumar/mdroid/fragment/CalenderFragment.java
@@ -36,7 +36,7 @@ public class CalenderFragment extends Fragment implements OnRefreshListener {
 	CalendarListAdapter calendarListAdapter;
 	SessionSetting session;
 	List<MoodleEvent> mEvents;
-	ArrayList<CalenderObject> listObjects = new ArrayList<CalenderObject>();
+	ArrayList<CalenderObject> listObjects = new ArrayList<>();
 	LinearLayout calenderEmptyLayout;
 	SwipeRefreshLayout swipeLayout;
 
@@ -111,7 +111,7 @@ public class CalenderFragment extends Fragment implements OnRefreshListener {
 			// Get course ids
 			List<MoodleCourse> mCourses = MoodleCourse.find(MoodleCourse.class,
 					"siteid = ?", siteid + "");
-			ArrayList<String> courseIds = new ArrayList<String>();
+			ArrayList<String> courseIds = new ArrayList<>();
 			for (int i = 0; i < mCourses.size(); i++)
 				courseIds.add(mCourses.get(i).getCourseid() + "");
 			syncStatus = est.syncEvents(courseIds);
@@ -133,7 +133,7 @@ public class CalenderFragment extends Fragment implements OnRefreshListener {
 		@Override
 		protected void onPostExecute(Boolean result) {
 			calendarListAdapter.notifyDataSetChanged();
-			if (listObjects.size() != 0)
+			if (!listObjects.isEmpty())
 				calenderEmptyLayout.setVisibility(LinearLayout.GONE);
 			swipeLayout.setRefreshing(false);
 		}
@@ -149,7 +149,7 @@ public class CalenderFragment extends Fragment implements OnRefreshListener {
 
 		public CalendarListAdapter(Context context) {
 			this.context = context;
-			if (listObjects.size() != 0)
+			if (!listObjects.isEmpty())
 				calenderEmptyLayout.setVisibility(LinearLayout.GONE);
 		}
 
@@ -231,10 +231,7 @@ public class CalenderFragment extends Fragment implements OnRefreshListener {
 
 		@Override
 		public boolean isItemViewTypePinned(int viewType) {
-			if (viewType == TYPE_DATE)
-				return true;
-			else
-				return false;
+			return viewType == TYPE_DATE;
 		}
 
 		@Override
@@ -264,7 +261,7 @@ public class CalenderFragment extends Fragment implements OnRefreshListener {
 	private void setupCalenderObjects() {
 		if (mEvents == null)
 			return;
-		if (mEvents.size() == 0)
+		if (mEvents.isEmpty())
 			return;
 
 		Collections.sort(mEvents, new Comparator<MoodleEvent>() {

--- a/app/src/main/java/in/co/praveenkumar/mdroid/fragment/CalenderFragment.java
+++ b/app/src/main/java/in/co/praveenkumar/mdroid/fragment/CalenderFragment.java
@@ -69,11 +69,11 @@ public class CalenderFragment extends Fragment implements OnRefreshListener {
 		session = new SessionSetting(context);
 		if (courseid == 0)
 			mEvents = MoodleEvent.find(MoodleEvent.class, "siteid = ?",
-					session.getCurrentSiteId() + "");
+					String.valueOf(session.getCurrentSiteId()));
 		else
 			mEvents = MoodleEvent.find(MoodleEvent.class,
-					"siteid = ? and courseid = ?", session.getCurrentSiteId()
-							+ "", courseid + "");
+					"siteid = ? and courseid = ?", String.valueOf(session.getCurrentSiteId())
+							, String.valueOf(courseid));
 		setupCalenderObjects();
 
 		calendarListAdapter = new CalendarListAdapter(context);
@@ -119,11 +119,11 @@ public class CalenderFragment extends Fragment implements OnRefreshListener {
 			if (syncStatus) {
 				if (courseid == 0)
 					mEvents = MoodleEvent.find(MoodleEvent.class, "siteid = ?",
-							session.getCurrentSiteId() + "");
+							String.valueOf(session.getCurrentSiteId()));
 				else
 					mEvents = MoodleEvent.find(MoodleEvent.class,
 							"siteid = ? and courseid = ?",
-							session.getCurrentSiteId() + "", courseid + "");
+							String.valueOf(session.getCurrentSiteId()), String.valueOf(courseid));
 				setupCalenderObjects();
 				return true;
 			} else

--- a/app/src/main/java/in/co/praveenkumar/mdroid/fragment/ContactFragment.java
+++ b/app/src/main/java/in/co/praveenkumar/mdroid/fragment/ContactFragment.java
@@ -81,7 +81,7 @@ public class ContactFragment extends Fragment implements OnRefreshListener {
 
 		public ContactListAdapter(Context context) {
 			this.context = context;
-			if (contacts.size() != 0)
+			if (!contacts.isEmpty())
 				chatEmptyLayout.setVisibility(LinearLayout.GONE);
 		}
 
@@ -183,10 +183,7 @@ public class ContactFragment extends Fragment implements OnRefreshListener {
 		protected Boolean doInBackground(String... params) {
 			ContactSyncTask cst = new ContactSyncTask(session.getmUrl(),
 					session.getToken(), session.getCurrentSiteId());
-			if (cst.syncAllContacts())
-				return true;
-			else
-				return false;
+			return cst.syncAllContacts();
 		}
 
 		@Override
@@ -194,7 +191,7 @@ public class ContactFragment extends Fragment implements OnRefreshListener {
 			contacts = MoodleContact.find(MoodleContact.class, "siteid = ?",
 					session.getCurrentSiteId() + "");
 			adapter.notifyDataSetChanged();
-			if (contacts.size() != 0)
+			if (!contacts.isEmpty())
 				chatEmptyLayout.setVisibility(LinearLayout.GONE);
 			swipeLayout.setRefreshing(false);
 		}

--- a/app/src/main/java/in/co/praveenkumar/mdroid/fragment/ContentFragment.java
+++ b/app/src/main/java/in/co/praveenkumar/mdroid/fragment/ContentFragment.java
@@ -41,7 +41,7 @@ public class ContentFragment extends Fragment implements OnRefreshListener {
 	int courseid;
 	CourseListAdapter courseContentListAdapter;
 	SessionSetting session;
-	ArrayList<CourseContentObject> listObjects = new ArrayList<CourseContentObject>();
+	ArrayList<CourseContentObject> listObjects = new ArrayList<>();
 	LinearLayout contentEmptyLayout;
 	SwipeRefreshLayout swipeLayout;
 
@@ -120,16 +120,13 @@ public class ContentFragment extends Fragment implements OnRefreshListener {
 			// Save all sections into a listObject array for easy access inside
 			mapSectionsToListObjects(sections);
 
-			if (syncStatus)
-				return true;
-			else
-				return false;
+			return syncStatus;
 		}
 
 		@Override
 		protected void onPostExecute(Boolean result) {
 			courseContentListAdapter.notifyDataSetChanged();
-			if (listObjects.size() != 0)
+			if (!listObjects.isEmpty())
 				contentEmptyLayout.setVisibility(LinearLayout.GONE);
 			swipeLayout.setRefreshing(false);
 		}
@@ -145,7 +142,7 @@ public class ContentFragment extends Fragment implements OnRefreshListener {
 
 		public CourseListAdapter(Context context) {
 			this.context = context;
-			if (listObjects.size() != 0)
+			if (!listObjects.isEmpty())
 				contentEmptyLayout.setVisibility(LinearLayout.GONE);
 		}
 
@@ -260,7 +257,7 @@ public class ContentFragment extends Fragment implements OnRefreshListener {
 						return;
 					}
 
-					if (module.getContents().size() == 0) {
+					if (module.getContents().isEmpty()) {
 						context.startActivity(i);
 						return;
 					}
@@ -291,10 +288,7 @@ public class ContentFragment extends Fragment implements OnRefreshListener {
 
 		@Override
 		public boolean isItemViewTypePinned(int viewType) {
-			if (viewType == TYPE_HEADER)
-				return true;
-			else
-				return false;
+			return viewType == TYPE_HEADER;
 		}
 
 		@Override
@@ -362,7 +356,7 @@ public class ContentFragment extends Fragment implements OnRefreshListener {
 		for (int i = 0; i < sections.size(); i++) {
 			section = sections.get(i);
 			modules = section.getModules();
-			if (modules.size() > 0) {
+			if (!modules.isEmpty()) {
 				CourseContentObject object = new CourseContentObject();
 				object.viewType = CourseListAdapter.TYPE_HEADER;
 				object.sectionid = section.getSectionid();

--- a/app/src/main/java/in/co/praveenkumar/mdroid/fragment/CourseFragment.java
+++ b/app/src/main/java/in/co/praveenkumar/mdroid/fragment/CourseFragment.java
@@ -110,7 +110,7 @@ public class CourseFragment extends Fragment implements OnRefreshListener {
 
 		public CourseListAdapter(Context context) {
 			this.context = context;
-			if (mCourses.size() != 0)
+			if (!mCourses.isEmpty())
 				courseEmptyLayout.setVisibility(LinearLayout.GONE);
 		}
 
@@ -274,10 +274,7 @@ public class CourseFragment extends Fragment implements OnRefreshListener {
 		protected Boolean doInBackground(String... params) {
 			CourseSyncTask cs = new CourseSyncTask(session.getmUrl(),
 					session.getToken(), session.getCurrentSiteId());
-			if (cs.syncUserCourses())
-				return true;
-			else
-				return false;
+			return cs.syncUserCourses();
 		}
 
 		@Override
@@ -294,7 +291,7 @@ public class CourseFragment extends Fragment implements OnRefreshListener {
 				mCourses = MoodleCourse.find(MoodleCourse.class,
 						"siteid = ? and ", session.getCurrentSiteId() + "");
 			courseListAdapter.notifyDataSetChanged();
-			if (mCourses.size() != 0)
+			if (!mCourses.isEmpty())
 				courseEmptyLayout.setVisibility(LinearLayout.GONE);
 			swipeLayout.setRefreshing(false);
 		}

--- a/app/src/main/java/in/co/praveenkumar/mdroid/fragment/DiscussionFragment.java
+++ b/app/src/main/java/in/co/praveenkumar/mdroid/fragment/DiscussionFragment.java
@@ -113,7 +113,7 @@ public class DiscussionFragment extends Fragment implements OnRefreshListener {
 
 		public TopicListAdapter(Context context) {
 			this.context = context;
-			if (mTopics.size() != 0)
+			if (!mTopics.isEmpty())
 				topicsEmptyLayout.setVisibility(LinearLayout.GONE);
 		}
 
@@ -202,7 +202,7 @@ public class DiscussionFragment extends Fragment implements OnRefreshListener {
 
 		@Override
 		public void notifyDataSetChanged() {
-			if (mTopics.size() != 0)
+			if (!mTopics.isEmpty())
 				topicsEmptyLayout.setVisibility(LinearLayout.GONE);
 			super.notifyDataSetChanged();
 		}

--- a/app/src/main/java/in/co/praveenkumar/mdroid/fragment/ForumFragment.java
+++ b/app/src/main/java/in/co/praveenkumar/mdroid/fragment/ForumFragment.java
@@ -91,7 +91,7 @@ public class ForumFragment extends Fragment implements OnRefreshListener {
 
 		public ForumListAdapter(Context context) {
 			this.context = context;
-			if (mForums.size() != 0)
+			if (!mForums.isEmpty())
 				forumEmptyLayout.setVisibility(LinearLayout.GONE);
 		}
 
@@ -191,7 +191,7 @@ public class ForumFragment extends Fragment implements OnRefreshListener {
 			// Get course ids
 			List<MoodleCourse> mCourses = MoodleCourse.find(MoodleCourse.class,
 					"siteid = ?", siteid + "");
-			ArrayList<String> courseIds = new ArrayList<String>();
+			ArrayList<String> courseIds = new ArrayList<>();
 			for (int i = 0; i < mCourses.size(); i++)
 				courseIds.add(mCourses.get(i).getCourseid() + "");
 			syncStatus = fst.syncForums(courseIds);
@@ -212,7 +212,7 @@ public class ForumFragment extends Fragment implements OnRefreshListener {
 		@Override
 		protected void onPostExecute(Boolean result) {
 			forumListAdapter.notifyDataSetChanged();
-			if (mForums.size() != 0)
+			if (!mForums.isEmpty())
 				forumEmptyLayout.setVisibility(LinearLayout.GONE);
 			swipeLayout.setRefreshing(false);
 		}

--- a/app/src/main/java/in/co/praveenkumar/mdroid/fragment/MessageListingFragment.java
+++ b/app/src/main/java/in/co/praveenkumar/mdroid/fragment/MessageListingFragment.java
@@ -39,7 +39,7 @@ import android.widget.TextView;
 public class MessageListingFragment extends Fragment implements
         OnRefreshListener {
     final String DEBUG_TAG = "MessageListingFragment";
-    List<ListMessage> messages = new ArrayList<MessageListingFragment.ListMessage>();
+    List<ListMessage> messages = new ArrayList<>();
 
     FragmentManager mFragmentManager;
     MessageListAdapter adapter;
@@ -116,10 +116,7 @@ public class MessageListingFragment extends Fragment implements
             // Sync from server and update
             MessageSyncTask mst = new MessageSyncTask(session.getmUrl(),
                     session.getToken(), session.getCurrentSiteId());
-            if (mst.syncMessages(session.getSiteInfo().getUserid()))
-                return true;
-            else
-                return false;
+            return mst.syncMessages(session.getSiteInfo().getUserid());
         }
 
         @Override
@@ -137,7 +134,7 @@ public class MessageListingFragment extends Fragment implements
 
         public MessageListAdapter(Context context) {
             this.context = context;
-            if (messages == null || messages.size() == 0)
+            if (messages == null || messages.isEmpty())
                 messagesEmptyLayout.setVisibility(LinearLayout.VISIBLE);
             else
                 messagesEmptyLayout.setVisibility(LinearLayout.GONE);
@@ -206,7 +203,7 @@ public class MessageListingFragment extends Fragment implements
 
         @Override
         public void notifyDataSetChanged() {
-            if (messages.size() != 0)
+            if (!messages.isEmpty())
                 messagesEmptyLayout.setVisibility(LinearLayout.GONE);
             super.notifyDataSetChanged();
         }
@@ -221,7 +218,7 @@ public class MessageListingFragment extends Fragment implements
     void setupMessages() {
         List<MoodleMessage> mMessages = MoodleMessage.find(MoodleMessage.class,
                 "siteid = ?", session.getCurrentSiteId() + "");
-        List<ListMessage> lMessages = new ArrayList<MessageListingFragment.ListMessage>();
+        List<ListMessage> lMessages = new ArrayList<>();
 
         // Sort messages with newest first in list
         Collections.sort(mMessages, new Comparator<MoodleMessage>() {
@@ -232,7 +229,7 @@ public class MessageListingFragment extends Fragment implements
             }
         });
 
-        List<Integer> userids = new ArrayList<Integer>();
+        List<Integer> userids = new ArrayList<>();
         int currentuserid = session.getSiteInfo().getUserid();
 
         for (int i = 0; i < mMessages.size(); i++) {

--- a/app/src/main/java/in/co/praveenkumar/mdroid/fragment/MessagingFragment.java
+++ b/app/src/main/java/in/co/praveenkumar/mdroid/fragment/MessagingFragment.java
@@ -233,7 +233,7 @@ public class MessagingFragment extends Fragment implements OnRefreshListener {
 				char firstChar = 0;
 				if (name.length() != 0)
 					firstChar = name.charAt(0);
-				viewHolder.userimage.setText(firstChar + "");
+				viewHolder.userimage.setText(String.valueOf(firstChar));
 				viewHolder.userimage.setBackgroundColor(LetterColor
 						.of(firstChar));
 
@@ -293,8 +293,8 @@ public class MessagingFragment extends Fragment implements OnRefreshListener {
 	void setupMessages() {
 		List<MoodleMessage> mMessages = MoodleMessage.find(MoodleMessage.class,
 				"useridfrom = ? and siteid = ? or useridto = ? and siteid = ?",
-				userid + "", session.getCurrentSiteId() + "", userid + "",
-				session.getCurrentSiteId() + "");
+				String.valueOf(userid), String.valueOf(session.getCurrentSiteId()), String.valueOf(userid),
+				String.valueOf(session.getCurrentSiteId()));
 
 		// Sort messages with newest last in list
 		Collections.sort(mMessages, new Comparator<MoodleMessage>() {

--- a/app/src/main/java/in/co/praveenkumar/mdroid/fragment/MessagingFragment.java
+++ b/app/src/main/java/in/co/praveenkumar/mdroid/fragment/MessagingFragment.java
@@ -47,7 +47,7 @@ import android.widget.Toast;
 public class MessagingFragment extends Fragment implements OnRefreshListener {
 	final String DEBUG_TAG = "MessageListingFragment";
 	Context context;
-	List<MoodleMessage> messages = new ArrayList<MoodleMessage>();
+	List<MoodleMessage> messages = new ArrayList<>();
 	MessageListAdapter adapter;
 	SessionSetting session;
 	LinearLayout messagingEmptyLayout;
@@ -144,10 +144,7 @@ public class MessagingFragment extends Fragment implements OnRefreshListener {
 			// Sync from server and update
 			MessageSyncTask mst = new MessageSyncTask(session.getmUrl(),
 					session.getToken(), session.getCurrentSiteId());
-			if (mst.syncMessages(session.getSiteInfo().getUserid()))
-				return true;
-			else
-				return false;
+			return mst.syncMessages(session.getSiteInfo().getUserid());
 		}
 
 		@Override
@@ -167,7 +164,7 @@ public class MessagingFragment extends Fragment implements OnRefreshListener {
 
 		public MessageListAdapter(Context context) {
 			this.context = context;
-			if (messages == null || messages.size() != 0)
+			if (messages == null || !messages.isEmpty())
 				messagingEmptyLayout.setVisibility(LinearLayout.GONE);
 		}
 
@@ -278,7 +275,7 @@ public class MessagingFragment extends Fragment implements OnRefreshListener {
 
 		@Override
 		public void notifyDataSetChanged() {
-			if (messages.size() != 0)
+			if (!messages.isEmpty())
 				messagingEmptyLayout.setVisibility(LinearLayout.GONE);
 			super.notifyDataSetChanged();
 		}

--- a/app/src/main/java/in/co/praveenkumar/mdroid/fragment/NotificationFragment.java
+++ b/app/src/main/java/in/co/praveenkumar/mdroid/fragment/NotificationFragment.java
@@ -155,7 +155,7 @@ public class NotificationFragment extends Fragment implements OnRefreshListener 
 
 		public NotificationListAdapter(Context context) {
 			this.context = context;
-			if (notifications.size() != 0)
+			if (!notifications.isEmpty())
 				chatEmptyLayout.setVisibility(LinearLayout.GONE);
 		}
 
@@ -217,7 +217,7 @@ public class NotificationFragment extends Fragment implements OnRefreshListener 
 		@Override
 		public void notifyDataSetChanged() {
 			super.notifyDataSetChanged();
-			if (notifications.size() != 0)
+			if (!notifications.isEmpty())
 				chatEmptyLayout.setVisibility(LinearLayout.GONE);
 			else
 				chatEmptyLayout.setVisibility(LinearLayout.VISIBLE);

--- a/app/src/main/java/in/co/praveenkumar/mdroid/fragment/ParticipantFragment.java
+++ b/app/src/main/java/in/co/praveenkumar/mdroid/fragment/ParticipantFragment.java
@@ -64,8 +64,8 @@ public class ParticipantFragment extends Fragment implements OnRefreshListener {
 		// Get sites info
 		session = new SessionSetting(getActivity());
 		participants = MoodleUser.find(MoodleUser.class,
-				"siteid = ? and courseid = ?", session.getCurrentSiteId() + "",
-				courseid + "");
+				"siteid = ? and courseid = ?", String.valueOf(session.getCurrentSiteId()),
+				String.valueOf(courseid));
 
 		adapter = new ParticipantListAdapter(getActivity());
 		participantList.setAdapter(adapter);
@@ -184,8 +184,8 @@ public class ParticipantFragment extends Fragment implements OnRefreshListener {
 		@Override
 		protected void onPostExecute(Boolean result) {
 			participants = MoodleUser.find(MoodleUser.class,
-					"siteid = ? and courseid = ?", session.getCurrentSiteId()
-							+ "", courseid + "");
+					"siteid = ? and courseid = ?", String.valueOf(session.getCurrentSiteId())
+							, String.valueOf(courseid));
 			adapter.notifyDataSetChanged();
 			if (participants.size() != 0)
 				listEmptyLayout.setVisibility(LinearLayout.GONE);

--- a/app/src/main/java/in/co/praveenkumar/mdroid/fragment/ParticipantFragment.java
+++ b/app/src/main/java/in/co/praveenkumar/mdroid/fragment/ParticipantFragment.java
@@ -98,7 +98,7 @@ public class ParticipantFragment extends Fragment implements OnRefreshListener {
 
 		public ParticipantListAdapter(Context context) {
 			this.context = context;
-			if (participants.size() != 0)
+			if (!participants.isEmpty())
 				listEmptyLayout.setVisibility(LinearLayout.GONE);
 		}
 
@@ -175,10 +175,7 @@ public class ParticipantFragment extends Fragment implements OnRefreshListener {
 		protected Boolean doInBackground(String... params) {
 			UserSyncTask ust = new UserSyncTask(session.getmUrl(),
 					session.getToken(), session.getCurrentSiteId());
-			if (ust.syncUsers(courseid))
-				return true;
-			else
-				return false;
+			return ust.syncUsers(courseid);
 		}
 
 		@Override
@@ -187,7 +184,7 @@ public class ParticipantFragment extends Fragment implements OnRefreshListener {
 					"siteid = ? and courseid = ?", String.valueOf(session.getCurrentSiteId())
 							, String.valueOf(courseid));
 			adapter.notifyDataSetChanged();
-			if (participants.size() != 0)
+			if (!participants.isEmpty())
 				listEmptyLayout.setVisibility(LinearLayout.GONE);
 			swipeLayout.setRefreshing(false);
 		}

--- a/app/src/main/java/in/co/praveenkumar/mdroid/fragment/PostFragment.java
+++ b/app/src/main/java/in/co/praveenkumar/mdroid/fragment/PostFragment.java
@@ -109,7 +109,7 @@ public class PostFragment extends Fragment implements OnRefreshListener {
 
 		public PostListAdapter(Context context) {
 			this.context = context;
-			if (mPosts.size() != 0)
+			if (!mPosts.isEmpty())
 				postsEmptyLayout.setVisibility(LinearLayout.GONE);
 		}
 
@@ -239,7 +239,7 @@ public class PostFragment extends Fragment implements OnRefreshListener {
 		@Override
 		protected void onPostExecute(Boolean result) {
 			postListAdapter.notifyDataSetChanged();
-			if (mPosts.size() != 0)
+			if (!mPosts.isEmpty())
 				postsEmptyLayout.setVisibility(LinearLayout.GONE);
 			swipeLayout.setRefreshing(false);
 		}

--- a/app/src/main/java/in/co/praveenkumar/mdroid/fragment/PostFragment.java
+++ b/app/src/main/java/in/co/praveenkumar/mdroid/fragment/PostFragment.java
@@ -86,8 +86,8 @@ public class PostFragment extends Fragment implements OnRefreshListener {
 
 		session = new SessionSetting(getActivity());
 		mPosts = MoodlePost.find(MoodlePost.class,
-				"siteid = ? and discussionid = ?", session.getCurrentSiteId()
-						+ "", discussionid + "");
+				"siteid = ? and discussionid = ?", String.valueOf(session.getCurrentSiteId())
+						, String.valueOf(discussionid));
 		sortPostsByTime();
 
 		ListView postList = (ListView) rootView.findViewById(R.id.content_post);
@@ -228,8 +228,8 @@ public class PostFragment extends Fragment implements OnRefreshListener {
 
 			if (syncStatus) {
 				mPosts = MoodlePost.find(MoodlePost.class,
-						"siteid = ? and discussionid = ?", siteid + "",
-						discussionid + "");
+						"siteid = ? and discussionid = ?", String.valueOf(siteid),
+						String.valueOf(discussionid));
 				sortPostsByTime();
 				return true;
 			} else

--- a/app/src/main/java/in/co/praveenkumar/mdroid/fragment/RightNavigationFragment.java
+++ b/app/src/main/java/in/co/praveenkumar/mdroid/fragment/RightNavigationFragment.java
@@ -121,7 +121,7 @@ public class RightNavigationFragment extends Fragment {
 			char firstChar = 0;
 			if (name.length() != 0)
 				firstChar = name.charAt(0);
-			viewHolder.userimage.setText(firstChar + "");
+			viewHolder.userimage.setText(String.valueOf(firstChar));
 			viewHolder.userimage.setBackgroundColor(LetterColor.of(firstChar));
 
 			// Name
@@ -134,7 +134,7 @@ public class RightNavigationFragment extends Fragment {
 				viewHolder.unreadcount.setVisibility(TextView.GONE);
 			else {
 				viewHolder.unreadcount.setVisibility(TextView.VISIBLE);
-				viewHolder.unreadcount.setText(count + "");
+				viewHolder.unreadcount.setText(String.valueOf(count));
 			}
 
 			switch (contacts.get(position).getStatus()) {

--- a/app/src/main/java/in/co/praveenkumar/mdroid/fragment/RightNavigationFragment.java
+++ b/app/src/main/java/in/co/praveenkumar/mdroid/fragment/RightNavigationFragment.java
@@ -86,7 +86,7 @@ public class RightNavigationFragment extends Fragment {
 
 		public RightNavListAdapter(Context context) {
 			this.context = context;
-			if (contacts.size() != 0)
+			if (!contacts.isEmpty())
 				chatEmptyLayout.setVisibility(LinearLayout.GONE);
 		}
 
@@ -119,7 +119,7 @@ public class RightNavigationFragment extends Fragment {
 			// Contact image color and value
 			String name = contacts.get(position).getFullname();
 			char firstChar = 0;
-			if (name.length() != 0)
+			if (!name.isEmpty())
 				firstChar = name.charAt(0);
 			viewHolder.userimage.setText(String.valueOf(firstChar));
 			viewHolder.userimage.setBackgroundColor(LetterColor.of(firstChar));
@@ -183,10 +183,7 @@ public class RightNavigationFragment extends Fragment {
 		protected Boolean doInBackground(String... params) {
 			ContactSyncTask cst = new ContactSyncTask(session.getmUrl(),
 					session.getToken(), session.getCurrentSiteId());
-			if (cst.syncAllContacts())
-				return true;
-			else
-				return false;
+			return cst.syncAllContacts();
 		}
 
 		@Override
@@ -194,7 +191,7 @@ public class RightNavigationFragment extends Fragment {
 			contacts = MoodleContact.find(MoodleContact.class, "siteid = ?",
 					session.getCurrentSiteId() + "");
 			adapter.notifyDataSetChanged();
-			if (contacts.size() != 0)
+			if (!contacts.isEmpty())
 				chatEmptyLayout.setVisibility(LinearLayout.GONE);
 		}
 

--- a/app/src/main/java/in/co/praveenkumar/mdroid/helper/IconMap.java
+++ b/app/src/main/java/in/co/praveenkumar/mdroid/helper/IconMap.java
@@ -58,7 +58,7 @@ public class IconMap {
 			if (contents == null)
 				return R.drawable.format_unknown;
 
-			if (contents.size() == 0)
+			if (contents.isEmpty())
 				return R.drawable.format_unknown;
 
 			String filename = contents.get(0).getFilename();

--- a/app/src/main/java/in/co/praveenkumar/mdroid/helper/SessionSetting.java
+++ b/app/src/main/java/in/co/praveenkumar/mdroid/helper/SessionSetting.java
@@ -66,7 +66,7 @@ public class SessionSetting {
 			List<MoodleSiteInfo> sites = MoodleSiteInfo
 					.listAll(MoodleSiteInfo.class);
 			// Check if at least one site is present in database
-			if (sites.size() != 0) {
+			if (!sites.isEmpty()) {
 				siteInfo = sites.get(0);
 
 				// Save this as current site for all future references.

--- a/app/src/main/java/in/co/praveenkumar/mdroid/helper/TimeFormat.java
+++ b/app/src/main/java/in/co/praveenkumar/mdroid/helper/TimeFormat.java
@@ -204,7 +204,7 @@ public class TimeFormat {
 		String AmPm = (c.get(Calendar.AM_PM) == Calendar.AM) ? "AM" : "PM";
 
 		// Because 12:07 AM better than 12:7 AM
-		String mins = (minute > 9) ? minute + "" : "0" + minute;
+		String mins = (minute > 9) ? String.valueOf(minute): "0" + minute;
 
 		if (year == yearnow || String.valueOf(year).length() != 4)
 			return day + " " + getMonthName(month) + " " + hour + ":" + mins

--- a/app/src/main/java/in/co/praveenkumar/mdroid/model/MoodleModule.java
+++ b/app/src/main/java/in/co/praveenkumar/mdroid/model/MoodleModule.java
@@ -170,7 +170,7 @@ public class MoodleModule extends SugarRecord<MoodleModule> {
 	 * @return
 	 */
 	public void setContents(List<MoodleModuleContent> contents) {
-		this.contents = new ArrayList<MoodleModuleContent>(contents);
+		this.contents = new ArrayList<>(contents);
 	}
 
 	/**

--- a/app/src/main/java/in/co/praveenkumar/mdroid/model/MoodleSection.java
+++ b/app/src/main/java/in/co/praveenkumar/mdroid/model/MoodleSection.java
@@ -98,7 +98,7 @@ public class MoodleSection extends SugarRecord<MoodleSection> {
 	 * @return
 	 */
 	public void setModules(List<MoodleModule> modules) {
-		this.modules = new ArrayList<MoodleModule>(modules);
+		this.modules = new ArrayList<>(modules);
 	}
 
 	/**

--- a/app/src/main/java/in/co/praveenkumar/mdroid/model/MoodleUser.java
+++ b/app/src/main/java/in/co/praveenkumar/mdroid/model/MoodleUser.java
@@ -133,7 +133,7 @@ public class MoodleUser extends SugarRecord<MoodleUser> {
 		super.save();
 
 		// Save users' enrolled courses
-		if (enrolledcourses == null || enrolledcourses.size() == 0)
+		if (enrolledcourses == null || enrolledcourses.isEmpty())
 			return;
 
 		MoodleUserCourse mUserCourse;
@@ -145,7 +145,7 @@ public class MoodleUser extends SugarRecord<MoodleUser> {
 			dbUserCourses = MoodleUserCourse.find(MoodleUserCourse.class,
 					"userid = ? and siteid = ? and courseid = ?", String.valueOf(userid),
 					String.valueOf(siteid), String.valueOf(mUserCourse.getCourseid()));
-			if (dbUserCourses != null && dbUserCourses.size() > 0)
+			if (dbUserCourses != null && !dbUserCourses.isEmpty())
 				mUserCourse.setId(dbUserCourses.get(0).getId());
 			mUserCourse.save();
 		}

--- a/app/src/main/java/in/co/praveenkumar/mdroid/model/MoodleUser.java
+++ b/app/src/main/java/in/co/praveenkumar/mdroid/model/MoodleUser.java
@@ -143,8 +143,8 @@ public class MoodleUser extends SugarRecord<MoodleUser> {
 			mUserCourse.setSiteid(this.siteid);
 			mUserCourse.setUserid(this.userid);
 			dbUserCourses = MoodleUserCourse.find(MoodleUserCourse.class,
-					"userid = ? and siteid = ? and courseid = ?", userid + "",
-					siteid + "", mUserCourse.getCourseid() + "");
+					"userid = ? and siteid = ? and courseid = ?", String.valueOf(userid),
+					String.valueOf(siteid), String.valueOf(mUserCourse.getCourseid()));
 			if (dbUserCourses != null && dbUserCourses.size() > 0)
 				mUserCourse.setId(dbUserCourses.get(0).getId());
 			mUserCourse.save();

--- a/app/src/main/java/in/co/praveenkumar/mdroid/moodlerest/MoodleRestCourse.java
+++ b/app/src/main/java/in/co/praveenkumar/mdroid/moodlerest/MoodleRestCourse.java
@@ -35,7 +35,7 @@ public class MoodleRestCourse {
 	 * @author Praveen Kumar Pendyala (praveen@praveenkumar.co.in)
 	 */
 	public ArrayList<MoodleCourse> getAllCourses() {
-		ArrayList<MoodleCourse> mCourses = new ArrayList<MoodleCourse>();
+		ArrayList<MoodleCourse> mCourses = new ArrayList<>();
 		String format = MoodleRestOption.RESPONSE_FORMAT;
 		String function = MoodleRestOption.FUNCTION_GET_ALL_COURSES;
 
@@ -82,7 +82,7 @@ public class MoodleRestCourse {
 	 * @author Praveen Kumar Pendyala (praveen@praveenkumar.co.in)
 	 */
 	public ArrayList<MoodleCourse> getEnrolledCourses(String userId) {
-		ArrayList<MoodleCourse> mCourses = new ArrayList<MoodleCourse>();
+		ArrayList<MoodleCourse> mCourses = new ArrayList<>();
 		String format = MoodleRestOption.RESPONSE_FORMAT;
 		String function = MoodleRestOption.FUNCTION_GET_ENROLLED_COURSES;
 

--- a/app/src/main/java/in/co/praveenkumar/mdroid/moodlerest/MoodleRestDiscussion.java
+++ b/app/src/main/java/in/co/praveenkumar/mdroid/moodlerest/MoodleRestDiscussion.java
@@ -44,7 +44,7 @@ public class MoodleRestDiscussion {
 			String params = "";
 
 			if (forumids == null)
-				forumids = new ArrayList<String>();
+				forumids = new ArrayList<>();
 
 			for (int i = 0; i < forumids.size(); i++)
 				params += "&forumids[" + i + "]="

--- a/app/src/main/java/in/co/praveenkumar/mdroid/moodlerest/MoodleRestEvent.java
+++ b/app/src/main/java/in/co/praveenkumar/mdroid/moodlerest/MoodleRestEvent.java
@@ -78,7 +78,7 @@ public class MoodleRestEvent {
 						+ URLEncoder.encode("0", "UTF-8");
 
 			if (ids == null)
-				ids = new ArrayList<String>();
+				ids = new ArrayList<>();
 
 			for (int i = 0; i < ids.size(); i++) {
 				switch (idType) {

--- a/app/src/main/java/in/co/praveenkumar/mdroid/moodlerest/MoodleRestForum.java
+++ b/app/src/main/java/in/co/praveenkumar/mdroid/moodlerest/MoodleRestForum.java
@@ -32,7 +32,7 @@ public class MoodleRestForum {
 	 * @author Praveen Kumar Pendyala (praveen@praveenkumar.co.in)
 	 */
 	public ArrayList<MoodleForum> getForums(String courseid) {
-		ArrayList<String> courseids = new ArrayList<String>();
+		ArrayList<String> courseids = new ArrayList<>();
 		courseids.add(courseid);
 		return getForums(courseids);
 	}
@@ -45,7 +45,7 @@ public class MoodleRestForum {
 	 * @author Praveen Kumar Pendyala (praveen@praveenkumar.co.in)
 	 */
 	public ArrayList<MoodleForum> getForums(ArrayList<String> courseids) {
-		ArrayList<MoodleForum> mForums = new ArrayList<MoodleForum>();
+		ArrayList<MoodleForum> mForums = new ArrayList<>();
 		String format = MoodleRestOption.RESPONSE_FORMAT;
 		String function = MoodleRestOption.FUNCTION_GET_FORUMS;
 

--- a/app/src/main/java/in/co/praveenkumar/mdroid/moodlerest/MoodleRestMessage.java
+++ b/app/src/main/java/in/co/praveenkumar/mdroid/moodlerest/MoodleRestMessage.java
@@ -38,7 +38,7 @@ public class MoodleRestMessage {
 	public Boolean sendMessage(MoodleMessage message) {
 		String format = MoodleRestOption.RESPONSE_FORMAT;
 		String function = MoodleRestOption.FUNCTION_SEND_MESSAGE;
-		ArrayList<MoodleMessage> mMessages = new ArrayList<MoodleMessage>();
+		ArrayList<MoodleMessage> mMessages = new ArrayList<>();
 
 		if (message == null) {
 			Log.d(DEBUG_TAG, "Message not setup correctly");
@@ -82,7 +82,7 @@ public class MoodleRestMessage {
 			if (mMessages == null)
 				return false;
 
-			if (mMessages.size() == 0)
+			if (mMessages.isEmpty())
 				return false;
 
 			MoodleMessage mMessage = mMessages.get(0);

--- a/app/src/main/java/in/co/praveenkumar/mdroid/moodlerest/MoodleRestPost.java
+++ b/app/src/main/java/in/co/praveenkumar/mdroid/moodlerest/MoodleRestPost.java
@@ -40,7 +40,7 @@ public class MoodleRestPost {
 			String params = "";
 
 			params += "&discussionid="
-					+ URLEncoder.encode(discussionid + "", "UTF-8");
+					+ URLEncoder.encode(String.valueOf(discussionid), "UTF-8");
 
 			// Build a REST call url to make a call.
 			String restUrl = mUrl + "/webservice/rest/server.php" + "?wstoken="

--- a/app/src/main/java/in/co/praveenkumar/mdroid/service/MDroidService.java
+++ b/app/src/main/java/in/co/praveenkumar/mdroid/service/MDroidService.java
@@ -123,12 +123,12 @@ public class MDroidService extends Service {
 				// Get list of favourites courses if no courseid is passed
 				if (courseid == -1)
 					mCourses = MoodleCourse.find(MoodleCourse.class,
-							"siteid = ? and is_fav_course = ?", site.getId()
-									+ "", "1");
+							"siteid = ? and is_fav_course = ?", String.valueOf(site.getId())
+									, "1");
 				else
 					mCourses = MoodleCourse.find(MoodleCourse.class,
-							"siteid = ? and courseid = ?", site.getId() + "",
-							courseid + "");
+							"siteid = ? and courseid = ?", String.valueOf(site.getId()),
+							String.valueOf(courseid));
 
 				// Contents sync
 				if (settings.getBoolean("notify_coursecontents", true))

--- a/app/src/main/java/in/co/praveenkumar/mdroid/service/MDroidService.java
+++ b/app/src/main/java/in/co/praveenkumar/mdroid/service/MDroidService.java
@@ -100,7 +100,7 @@ public class MDroidService extends Service {
 			int messageCount = 0;
 			int eventCount = 0;
 
-			List<MoodleSiteInfo> mSites = new ArrayList<MoodleSiteInfo>();
+			List<MoodleSiteInfo> mSites = new ArrayList<>();
 			MoodleSiteInfo site;
 
 			// Get list of accounts in app if no siteid param is passed
@@ -111,14 +111,14 @@ public class MDroidService extends Service {
 				mSites.add(site);
 			}
 
-			if (mSites == null || mSites.size() == 0)
+			if (mSites == null || mSites.isEmpty())
 				return false;
 
 			// Loop through all sites for checking contents
 			for (int i = 0; i < mSites.size(); i++) {
 				site = mSites.get(i);
 
-				List<MoodleCourse> mCourses = new ArrayList<MoodleCourse>();
+				List<MoodleCourse> mCourses = new ArrayList<>();
 
 				// Get list of favourites courses if no courseid is passed
 				if (courseid == -1)
@@ -189,7 +189,7 @@ public class MDroidService extends Service {
 		 */
 		private int syncCourseContents(MoodleSiteInfo site,
 				List<MoodleCourse> mCourses) {
-			if (mCourses == null || mCourses.size() == 0)
+			if (mCourses == null || mCourses.isEmpty())
 				return 0;
 
 			CourseContentSyncTask ccst = new CourseContentSyncTask(
@@ -211,10 +211,10 @@ public class MDroidService extends Service {
 		 * @return Notification count
 		 */
 		private int syncForums(MoodleSiteInfo site, List<MoodleCourse> mCourses) {
-			if (mCourses == null || mCourses.size() == 0)
+			if (mCourses == null || mCourses.isEmpty())
 				return 0;
 
-			ArrayList<String> courseids = new ArrayList<String>();
+			ArrayList<String> courseids = new ArrayList<>();
 			ForumSyncTask fst = new ForumSyncTask(site.getSiteurl(),
 					site.getToken(), site.getId(), notifications);
 			for (int i = 0; i < mCourses.size(); i++)
@@ -235,12 +235,12 @@ public class MDroidService extends Service {
 		 */
 		private int syncDiscussions(MoodleSiteInfo site,
 				List<MoodleCourse> mCourses) {
-			if (mCourses == null || mCourses.size() == 0)
+			if (mCourses == null || mCourses.isEmpty())
 				return 0;
 
 			DiscussionSyncTask dst = new DiscussionSyncTask(site.getSiteurl(),
 					site.getToken(), site.getId(), notifications);
-			List<MoodleForum> forums = new ArrayList<MoodleForum>();
+			List<MoodleForum> forums = new ArrayList<>();
 
 			// Get list of discussions to sync
 			for (int i = 0; i < mCourses.size(); i++)
@@ -249,7 +249,7 @@ public class MDroidService extends Service {
 								.getCourseid() + "", site.getId() + ""));
 
 			// Make an Arraylist of ids for above discussions
-			ArrayList<String> forumids = new ArrayList<String>();
+			ArrayList<String> forumids = new ArrayList<>();
 			for (int i = 0; i < forums.size(); i++)
 				forumids.add(forums.get(i).getForumid() + "");
 
@@ -267,12 +267,12 @@ public class MDroidService extends Service {
 		 * @return Notification count
 		 */
 		private int syncPosts(MoodleSiteInfo site, List<MoodleCourse> mCourses) {
-			if (mCourses == null || mCourses.size() == 0)
+			if (mCourses == null || mCourses.isEmpty())
 				return 0;
 
 			PostSyncTask pst = new PostSyncTask(site.getSiteurl(),
 					site.getToken(), site.getId(), notifications);
-			List<MoodleDiscussion> discussions = new ArrayList<MoodleDiscussion>();
+			List<MoodleDiscussion> discussions = new ArrayList<>();
 
 			// Get list of discussions to sync
 			for (int i = 0; i < mCourses.size(); i++)
@@ -281,7 +281,7 @@ public class MDroidService extends Service {
 						mCourses.get(i).getCourseid() + "", site.getId() + ""));
 
 			// Make an Arraylist of ids for above discussions
-			ArrayList<Integer> discussionids = new ArrayList<Integer>();
+			ArrayList<Integer> discussionids = new ArrayList<>();
 			for (int i = 0; i < discussions.size(); i++)
 				discussionids.add(discussions.get(i).getDiscussionid());
 
@@ -314,10 +314,10 @@ public class MDroidService extends Service {
 		 * @return Notification count
 		 */
 		private int syncEvents(MoodleSiteInfo site, List<MoodleCourse> mCourses) {
-			if (mCourses == null || mCourses.size() == 0)
+			if (mCourses == null || mCourses.isEmpty())
 				return 0;
 
-			ArrayList<String> courseids = new ArrayList<String>();
+			ArrayList<String> courseids = new ArrayList<>();
 			EventSyncTask est = new EventSyncTask(site.getSiteurl(),
 					site.getToken(), site.getId(), notifications);
 			for (int i = 0; i < mCourses.size(); i++)
@@ -338,7 +338,7 @@ public class MDroidService extends Service {
 		 */
 		private int syncParticipants(MoodleSiteInfo site,
 				List<MoodleCourse> mCourses) {
-			if (mCourses == null || mCourses.size() == 0)
+			if (mCourses == null || mCourses.isEmpty())
 				return 0;
 
 			UserSyncTask ust = new UserSyncTask(site.getSiteurl(),

--- a/app/src/main/java/in/co/praveenkumar/mdroid/task/ContactSyncTask.java
+++ b/app/src/main/java/in/co/praveenkumar/mdroid/task/ContactSyncTask.java
@@ -158,7 +158,7 @@ public class ContactSyncTask {
 				dbContacts = MoodleContact.find(MoodleContact.class,
 						"contactid = ? and siteid = ?", contacts.get(i)
 								.getContactid() + "", siteid + "");
-				if (dbContacts.size() > 0)
+				if (!dbContacts.isEmpty())
 					contact.setId(dbContacts.get(0).getId());
 
 				// set notifications if enabled

--- a/app/src/main/java/in/co/praveenkumar/mdroid/task/CourseContentSyncTask.java
+++ b/app/src/main/java/in/co/praveenkumar/mdroid/task/CourseContentSyncTask.java
@@ -81,7 +81,7 @@ public class CourseContentSyncTask {
 		// Get the course from database for all future use
 		List<MoodleCourse> dbCourses = MoodleCourse.find(MoodleCourse.class,
 				"siteid = ? and courseid = ?", String.valueOf(siteid), String.valueOf(courseid));
-		if (dbCourses == null || dbCourses.size() == 0) {
+		if (dbCourses == null || dbCourses.isEmpty()) {
 			error = "Course not found in database!";
 			return false;
 		}
@@ -97,7 +97,7 @@ public class CourseContentSyncTask {
 		}
 
 		// Some network or encoding issue.
-		if (mSections.size() == 0) {
+		if (mSections.isEmpty()) {
 			error = "No data received! Permissions issue?";
 			return false;
 		}
@@ -115,7 +115,7 @@ public class CourseContentSyncTask {
 			dbSections = MoodleSection.find(MoodleSection.class,
 					"sectionid = ? and siteid = ?",
 					section.getSectionid() + "", section.getSiteid() + "");
-			if (dbSections.size() > 0)
+			if (!dbSections.isEmpty())
 				section.setId(dbSections.get(0).getId()); // updates on save()
 			section.save();
 
@@ -162,7 +162,7 @@ public class CourseContentSyncTask {
 			dbModules = MoodleModule.find(MoodleModule.class,
 					"moduleid = ? and siteid = ?", module.getModuleid() + "",
 					module.getSiteid() + "");
-			if (dbModules.size() > 0)
+			if (!dbModules.isEmpty())
 				module.setId(dbModules.get(0).getId()); // updates on save()
 			// set notifications if enabled
 			else if (notification) {
@@ -217,7 +217,7 @@ public class CourseContentSyncTask {
 			dbContents = MoodleModuleContent.find(MoodleModuleContent.class,
 					"parentid = ? and siteid = ?", content.getParentid() + "",
 					content.getSiteid() + "");
-			if (dbContents.size() > 0)
+			if (!dbContents.isEmpty())
 				content.setId(dbContents.get(0).getId()); // updates on save()
 			content.save();
 		}
@@ -238,7 +238,7 @@ public class CourseContentSyncTask {
 	 */
 	public ArrayList<MoodleSection> getCourseContents(int courseid) {
 		List<MoodleSection> sections = MoodleSection.find(MoodleSection.class,
-				"courseid = ? and siteid = ?", String.valueOf(courseid), String.valueOf(siteid));
+				"courseid = ? and siteid = ?", courseid + "", siteid + "");
 
 		// Add modules to sections
 		List<MoodleModule> dbModules;
@@ -258,6 +258,6 @@ public class CourseContentSyncTask {
 			sections.get(i).setModules(dbModules);
 		}
 
-		return new ArrayList<MoodleSection>(sections);
+		return new ArrayList<>(sections);
 	}
 }

--- a/app/src/main/java/in/co/praveenkumar/mdroid/task/CourseContentSyncTask.java
+++ b/app/src/main/java/in/co/praveenkumar/mdroid/task/CourseContentSyncTask.java
@@ -80,7 +80,7 @@ public class CourseContentSyncTask {
 
 		// Get the course from database for all future use
 		List<MoodleCourse> dbCourses = MoodleCourse.find(MoodleCourse.class,
-				"siteid = ? and courseid = ?", siteid + "", courseid + "");
+				"siteid = ? and courseid = ?", String.valueOf(siteid), String.valueOf(courseid));
 		if (dbCourses == null || dbCourses.size() == 0) {
 			error = "Course not found in database!";
 			return false;
@@ -88,8 +88,7 @@ public class CourseContentSyncTask {
 		course = dbCourses.get(0);
 
 		MoodleRestCourseContent mrcc = new MoodleRestCourseContent(mUrl, token);
-		ArrayList<MoodleSection> mSections = mrcc.getCourseContent(courseid
-				+ "");
+		ArrayList<MoodleSection> mSections = mrcc.getCourseContent(String.valueOf(courseid));
 
 		/** Error checking **/
 		if (mSections == null) {
@@ -239,20 +238,20 @@ public class CourseContentSyncTask {
 	 */
 	public ArrayList<MoodleSection> getCourseContents(int courseid) {
 		List<MoodleSection> sections = MoodleSection.find(MoodleSection.class,
-				"courseid = ? and siteid = ?", courseid + "", siteid + "");
+				"courseid = ? and siteid = ?", String.valueOf(courseid), String.valueOf(siteid));
 
 		// Add modules to sections
 		List<MoodleModule> dbModules;
 		List<MoodleModuleContent> dbContents;
 		for (int i = 0; i < sections.size(); i++) {
 			dbModules = MoodleModule.find(MoodleModule.class, "parentid = ?",
-					sections.get(i).getId() + "");
+					String.valueOf(sections.get(i).getId()));
 
 			// Set module contents to modules
 			for (int j = 0; j < dbModules.size(); j++) {
 				dbContents = MoodleModuleContent.find(
-						MoodleModuleContent.class, "parentid = ?", dbModules
-								.get(j).getId() + "");
+						MoodleModuleContent.class, "parentid = ?", String.valueOf(dbModules
+								.get(j).getId()));
 				dbModules.get(j).setContents(dbContents);
 			}
 

--- a/app/src/main/java/in/co/praveenkumar/mdroid/task/CourseSyncTask.java
+++ b/app/src/main/java/in/co/praveenkumar/mdroid/task/CourseSyncTask.java
@@ -41,7 +41,7 @@ public class CourseSyncTask {
 
 		/** Error checking **/
 		// Some network or encoding issue.
-		if (mCourses.size() == 0) {
+		if (mCourses.isEmpty()) {
 			error = "Network issue!";
 			return false;
 		}
@@ -63,7 +63,7 @@ public class CourseSyncTask {
 			dbCourses = MoodleCourse.find(MoodleCourse.class,
 					"courseid = ? and siteid = ?", course.getCourseid() + "",
 					course.getSiteid() + "");
-			if (dbCourses != null && dbCourses.size() > 0) {
+			if (dbCourses != null && !dbCourses.isEmpty()) {
 				// Set app specific fields explicitly
 				course.setId(dbCourses.get(0).getId());
 				course.setIsUserCourse(dbCourses.get(0).getIsUserCourse());
@@ -101,7 +101,7 @@ public class CourseSyncTask {
 			return false;
 
 		// Some network or encoding issue.
-		if (mCourses.size() == 0)
+		if (mCourses.isEmpty())
 			return false;
 
 		// Moodle exception
@@ -120,7 +120,7 @@ public class CourseSyncTask {
 			dbCourses = MoodleCourse.find(MoodleCourse.class,
 					"courseid = ? and siteid = ?", course.getCourseid() + "",
 					course.getSiteid() + "");
-			if (dbCourses.size() > 0) {
+			if (!dbCourses.isEmpty()) {
 				// Set app specific fields explicitly
 				course.setId(dbCourses.get(0).getId());
 				course.setIsFavCourse(dbCourses.get(0).getIsFavCourse());

--- a/app/src/main/java/in/co/praveenkumar/mdroid/task/CourseSyncTask.java
+++ b/app/src/main/java/in/co/praveenkumar/mdroid/task/CourseSyncTask.java
@@ -93,7 +93,7 @@ public class CourseSyncTask {
 		int userid = site.getUserid();
 
 		MoodleRestCourse mrc = new MoodleRestCourse(mUrl, token);
-		ArrayList<MoodleCourse> mCourses = mrc.getEnrolledCourses(userid + "");
+		ArrayList<MoodleCourse> mCourses = mrc.getEnrolledCourses(String.valueOf(userid));
 
 		/** Error checking **/
 		// Some network or encoding issue.

--- a/app/src/main/java/in/co/praveenkumar/mdroid/task/DiscussionSyncTask.java
+++ b/app/src/main/java/in/co/praveenkumar/mdroid/task/DiscussionSyncTask.java
@@ -70,8 +70,8 @@ public class DiscussionSyncTask {
 	 * @author Praveen Kumar Pendyala (praveen@praveenkumar.co.in)
 	 */
 	public Boolean syncDiscussions(int forumid) {
-		ArrayList<String> forumids = new ArrayList<String>();
-		forumids.add(String.valueOf(forumid));
+		ArrayList<String> forumids = new ArrayList<>();
+		forumids.add(forumid + "");
 		return syncDiscussions(forumids);
 	}
 
@@ -94,7 +94,7 @@ public class DiscussionSyncTask {
 		}
 
 		// Moodle exception
-		if (mTopics.size() == 0) {
+		if (mTopics.isEmpty()) {
 			error = "No data received";
 			// No additional debug info as that needs context
 			return false;
@@ -109,7 +109,7 @@ public class DiscussionSyncTask {
 			dbTopics = MoodleDiscussion.find(MoodleDiscussion.class,
 					"discussionid = ? and siteid = ?", String.valueOf(topic.getDiscussionid())
 							, String.valueOf(siteid));
-			if (dbTopics.size() > 0)
+			if (!dbTopics.isEmpty())
 				topic.setId(dbTopics.get(0).getId());
 
 			// set notifications if enabled
@@ -117,7 +117,7 @@ public class DiscussionSyncTask {
 				List<MoodleCourse> dbCourses = MoodleCourse.find(
 						MoodleCourse.class, "courseid = ? and siteid = ?",
 						String.valueOf(siteid), String.valueOf(topic.getCourseid()));
-				MoodleCourse course = (dbCourses != null && dbCourses.size() > 0) ? dbCourses
+				MoodleCourse course = (dbCourses != null && !dbCourses.isEmpty()) ? dbCourses
 						.get(0) : null;
 
 				if (course != null) {

--- a/app/src/main/java/in/co/praveenkumar/mdroid/task/DiscussionSyncTask.java
+++ b/app/src/main/java/in/co/praveenkumar/mdroid/task/DiscussionSyncTask.java
@@ -71,7 +71,7 @@ public class DiscussionSyncTask {
 	 */
 	public Boolean syncDiscussions(int forumid) {
 		ArrayList<String> forumids = new ArrayList<String>();
-		forumids.add(forumid + "");
+		forumids.add(String.valueOf(forumid));
 		return syncDiscussions(forumids);
 	}
 
@@ -107,8 +107,8 @@ public class DiscussionSyncTask {
 			topic.setSiteid(siteid);
 
 			dbTopics = MoodleDiscussion.find(MoodleDiscussion.class,
-					"discussionid = ? and siteid = ?", topic.getDiscussionid()
-							+ "", siteid + "");
+					"discussionid = ? and siteid = ?", String.valueOf(topic.getDiscussionid())
+							, String.valueOf(siteid));
 			if (dbTopics.size() > 0)
 				topic.setId(dbTopics.get(0).getId());
 
@@ -116,7 +116,7 @@ public class DiscussionSyncTask {
 			else if (notification) {
 				List<MoodleCourse> dbCourses = MoodleCourse.find(
 						MoodleCourse.class, "courseid = ? and siteid = ?",
-						siteid + "", topic.getCourseid() + "");
+						String.valueOf(siteid), String.valueOf(topic.getCourseid()));
 				MoodleCourse course = (dbCourses != null && dbCourses.size() > 0) ? dbCourses
 						.get(0) : null;
 

--- a/app/src/main/java/in/co/praveenkumar/mdroid/task/EventSyncTask.java
+++ b/app/src/main/java/in/co/praveenkumar/mdroid/task/EventSyncTask.java
@@ -73,7 +73,7 @@ public class EventSyncTask {
 	 */
 	public Boolean syncEvents(int courseid) {
 		ArrayList<String> courseids = new ArrayList<String>();
-		courseids.add(courseid + "");
+		courseids.add(String.valueOf(courseid));
 		return syncEvents(courseids);
 	}
 
@@ -116,11 +116,11 @@ public class EventSyncTask {
 				event.setSiteid(siteid);
 
 				dbEvents = MoodleEvent.find(MoodleEvent.class,
-						"eventid = ? and siteid = ?", event.getEventid() + "",
-						siteid + "");
+						"eventid = ? and siteid = ?", String.valueOf(event.getEventid()),
+						String.valueOf(siteid));
 				dbCourses = MoodleCourse.find(MoodleCourse.class,
 						"courseid = ? and siteid = ?",
-						event.getCourseid() + "", siteid + "");
+						String.valueOf(event.getCourseid()), String.valueOf(siteid));
 				if (dbCourses.size() > 0)
 					event.setCoursename(dbCourses.get(0).getShortname());
 				if (dbEvents.size() > 0)

--- a/app/src/main/java/in/co/praveenkumar/mdroid/task/EventSyncTask.java
+++ b/app/src/main/java/in/co/praveenkumar/mdroid/task/EventSyncTask.java
@@ -72,8 +72,8 @@ public class EventSyncTask {
 	 * @author Praveen Kumar Pendyala (praveen@praveenkumar.co.in)
 	 */
 	public Boolean syncEvents(int courseid) {
-		ArrayList<String> courseids = new ArrayList<String>();
-		courseids.add(String.valueOf(courseid));
+		ArrayList<String> courseids = new ArrayList<>();
+		courseids.add(courseid + "");
 		return syncEvents(courseids);
 	}
 
@@ -121,9 +121,9 @@ public class EventSyncTask {
 				dbCourses = MoodleCourse.find(MoodleCourse.class,
 						"courseid = ? and siteid = ?",
 						String.valueOf(event.getCourseid()), String.valueOf(siteid));
-				if (dbCourses.size() > 0)
+				if (!dbCourses.isEmpty())
 					event.setCoursename(dbCourses.get(0).getShortname());
-				if (dbEvents.size() > 0)
+				if (!dbEvents.isEmpty())
 					event.setId(dbEvents.get(0).getId());
 
 				// set notifications if enabled

--- a/app/src/main/java/in/co/praveenkumar/mdroid/task/ForumSyncTask.java
+++ b/app/src/main/java/in/co/praveenkumar/mdroid/task/ForumSyncTask.java
@@ -71,8 +71,8 @@ public class ForumSyncTask {
 	 * @author Praveen Kumar Pendyala (praveen@praveenkumar.co.in)
 	 */
 	public Boolean syncForums(int courseid) {
-		ArrayList<String> courseids = new ArrayList<String>();
-		courseids.add(String.valueOf(courseid));
+		ArrayList<String> courseids = new ArrayList<>();
+		courseids.add(courseid + "");
 		return syncForums(courseids);
 	}
 
@@ -95,7 +95,7 @@ public class ForumSyncTask {
 		}
 
 		// Moodle exception
-		if (mForums.size() == 0) {
+		if (mForums.isEmpty()) {
 			error = "No data received";
 			// No additional debug info as that needs context
 			return false;
@@ -116,9 +116,9 @@ public class ForumSyncTask {
 			dbCourses = MoodleCourse.find(MoodleCourse.class,
 					"courseid = ? and siteid = ?", String.valueOf(forum.getCourseid()),
 					String.valueOf(siteid));
-			if (dbCourses.size() > 0)
+			if (!dbCourses.isEmpty())
 				forum.setCoursename(dbCourses.get(0).getShortname());
-			if (dbForums.size() > 0)
+			if (!dbForums.isEmpty())
 				forum.setId(dbForums.get(0).getId());
 			// set notifications if enabled
 			else if (notification) {

--- a/app/src/main/java/in/co/praveenkumar/mdroid/task/ForumSyncTask.java
+++ b/app/src/main/java/in/co/praveenkumar/mdroid/task/ForumSyncTask.java
@@ -72,7 +72,7 @@ public class ForumSyncTask {
 	 */
 	public Boolean syncForums(int courseid) {
 		ArrayList<String> courseids = new ArrayList<String>();
-		courseids.add(courseid + "");
+		courseids.add(String.valueOf(courseid));
 		return syncForums(courseids);
 	}
 
@@ -111,11 +111,11 @@ public class ForumSyncTask {
 			 * -TODO- Improve this search with only Sql operation
 			 */
 			dbForums = MoodleForum.find(MoodleForum.class,
-					"forumid = ? and siteid = ?", forum.getForumid() + "",
-					siteid + "");
+					"forumid = ? and siteid = ?", String.valueOf(forum.getForumid()),
+					String.valueOf(siteid));
 			dbCourses = MoodleCourse.find(MoodleCourse.class,
-					"courseid = ? and siteid = ?", forum.getCourseid() + "",
-					siteid + "");
+					"courseid = ? and siteid = ?", String.valueOf(forum.getCourseid()),
+					String.valueOf(siteid));
 			if (dbCourses.size() > 0)
 				forum.setCoursename(dbCourses.get(0).getShortname());
 			if (dbForums.size() > 0)

--- a/app/src/main/java/in/co/praveenkumar/mdroid/task/MessageSyncTask.java
+++ b/app/src/main/java/in/co/praveenkumar/mdroid/task/MessageSyncTask.java
@@ -115,7 +115,7 @@ public class MessageSyncTask {
 				dbMessages = MoodleMessage.find(MoodleMessage.class,
 						"messageid = ? and siteid = ?", String.valueOf(message.getMessageid())
 								, String.valueOf(siteid));
-				if (dbMessages.size() > 0)
+				if (!dbMessages.isEmpty())
 					message.setId(dbMessages.get(0).getId());
 				// set notifications if enabled
 				else if (notification

--- a/app/src/main/java/in/co/praveenkumar/mdroid/task/MessageSyncTask.java
+++ b/app/src/main/java/in/co/praveenkumar/mdroid/task/MessageSyncTask.java
@@ -113,8 +113,8 @@ public class MessageSyncTask {
 				 * -TODO- Improve this search with only Sql operation
 				 */
 				dbMessages = MoodleMessage.find(MoodleMessage.class,
-						"messageid = ? and siteid = ?", message.getMessageid()
-								+ "", siteid + "");
+						"messageid = ? and siteid = ?", String.valueOf(message.getMessageid())
+								, String.valueOf(siteid));
 				if (dbMessages.size() > 0)
 					message.setId(dbMessages.get(0).getId());
 				// set notifications if enabled

--- a/app/src/main/java/in/co/praveenkumar/mdroid/task/PostSyncTask.java
+++ b/app/src/main/java/in/co/praveenkumar/mdroid/task/PostSyncTask.java
@@ -101,7 +101,7 @@ public class PostSyncTask {
 				dbPosts = MoodlePost.find(MoodlePost.class,
 						"postid = ? and siteid = ?", String.valueOf(post.getPostid()),
 						String.valueOf(siteid));
-				if (dbPosts.size() > 0)
+				if (!dbPosts.isEmpty())
 					post.setId(dbPosts.get(0).getId());
 
 				// set notifications if enabled
@@ -110,8 +110,7 @@ public class PostSyncTask {
 							.find(MoodleDiscussion.class,
 									"discussionid = ? and siteid = ?", String.valueOf(siteid)
 											, String.valueOf(discussionid));
-					MoodleDiscussion discussion = (dbDiscussions != null && dbDiscussions
-							.size() > 0) ? dbDiscussions.get(0) : null;
+					MoodleDiscussion discussion = (dbDiscussions != null && !dbDiscussions.isEmpty()) ? dbDiscussions.get(0) : null;
 
 					if (discussion != null) {
 						new MDroidNotification(siteid,
@@ -143,7 +142,7 @@ public class PostSyncTask {
 	public Boolean syncPosts(ArrayList<Integer> discussionids) {
 		Boolean status = true;
 
-		if (discussionids == null || discussionids.size() == 0)
+		if (discussionids == null || discussionids.isEmpty())
 			return false;
 
 		for (int i = 0; i < discussionids.size(); i++)

--- a/app/src/main/java/in/co/praveenkumar/mdroid/task/PostSyncTask.java
+++ b/app/src/main/java/in/co/praveenkumar/mdroid/task/PostSyncTask.java
@@ -99,8 +99,8 @@ public class PostSyncTask {
 				post.setSiteid(siteid);
 
 				dbPosts = MoodlePost.find(MoodlePost.class,
-						"postid = ? and siteid = ?", post.getPostid() + "",
-						siteid + "");
+						"postid = ? and siteid = ?", String.valueOf(post.getPostid()),
+						String.valueOf(siteid));
 				if (dbPosts.size() > 0)
 					post.setId(dbPosts.get(0).getId());
 
@@ -108,8 +108,8 @@ public class PostSyncTask {
 				else if (notification) {
 					List<MoodleDiscussion> dbDiscussions = MoodleDiscussion
 							.find(MoodleDiscussion.class,
-									"discussionid = ? and siteid = ?", siteid
-											+ "", discussionid + "");
+									"discussionid = ? and siteid = ?", String.valueOf(siteid)
+											, String.valueOf(discussionid));
 					MoodleDiscussion discussion = (dbDiscussions != null && dbDiscussions
 							.size() > 0) ? dbDiscussions.get(0) : null;
 

--- a/app/src/main/java/in/co/praveenkumar/mdroid/task/UserSyncTask.java
+++ b/app/src/main/java/in/co/praveenkumar/mdroid/task/UserSyncTask.java
@@ -74,7 +74,7 @@ public class UserSyncTask {
 
 		/** Error checking **/
 		// Some network or encoding issue.
-		if (mUsers == null || mUsers.size() == 0) {
+		if (mUsers == null || mUsers.isEmpty()) {
 			error = "No users found!";
 			return false;
 		}
@@ -89,14 +89,14 @@ public class UserSyncTask {
 			dbUsers = MoodleUser.find(MoodleUser.class,
 					"userid = ? and siteid = ? and courseid = ?",
 					String.valueOf(mUser.getUserid()), String.valueOf(siteid), String.valueOf(courseid));
-			if (dbUsers.size() > 0)
+			if (!dbUsers.isEmpty())
 				mUser.setId(dbUsers.get(0).getId());
 			// set notifications if enabled
 			else if (notification) {
 				List<MoodleCourse> dbCourses = MoodleCourse.find(
 						MoodleCourse.class, "courseid = ? and siteid = ?",
 						String.valueOf(siteid), String.valueOf(courseid));
-				MoodleCourse course = (dbCourses != null && dbCourses.size() > 0) ? dbCourses
+				MoodleCourse course = (dbCourses != null && !dbCourses.isEmpty()) ? dbCourses
 						.get(0) : null;
 
 				if (course != null) {

--- a/app/src/main/java/in/co/praveenkumar/mdroid/task/UserSyncTask.java
+++ b/app/src/main/java/in/co/praveenkumar/mdroid/task/UserSyncTask.java
@@ -88,14 +88,14 @@ public class UserSyncTask {
 
 			dbUsers = MoodleUser.find(MoodleUser.class,
 					"userid = ? and siteid = ? and courseid = ?",
-					mUser.getUserid() + "", siteid + "", courseid + "");
+					String.valueOf(mUser.getUserid()), String.valueOf(siteid), String.valueOf(courseid));
 			if (dbUsers.size() > 0)
 				mUser.setId(dbUsers.get(0).getId());
 			// set notifications if enabled
 			else if (notification) {
 				List<MoodleCourse> dbCourses = MoodleCourse.find(
 						MoodleCourse.class, "courseid = ? and siteid = ?",
-						siteid + "", courseid + "");
+						String.valueOf(siteid), String.valueOf(courseid));
 				MoodleCourse course = (dbCourses != null && dbCourses.size() > 0) ? dbCourses
 						.get(0) : null;
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2131 - “Primitives should not be boxed just for "String" conversion”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2131
Please let me know if you have any questions.
Ayman Abdelghany.